### PR TITLE
Fix copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
-Copyright (c) <2019> mrlynch(no rights reserved)
+Copyright (c) <2019> The Hush Developers
+Copyright (c) <2019> The SuperNET Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.


### PR DESCRIPTION
Removing the names of copyright holders is not OK

This changes the copyright of 7SeasAndroid to be held by SuperNET devs